### PR TITLE
feat: add file index config

### DIFF
--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -47,6 +47,14 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
     }
 }
 
+export interface ContextConfiguration {
+    gitIgnoreFilePatterns?: string[]
+    includeSymLinks?: boolean
+    validFileExtensions?: string[]
+    maxFileSizeMb?: number
+    maxIndexSizeMb?: number
+}
+
 /**
  * Extended Client information, passed from client extension to server at initialization.
  * Use to pass additional information about Client Extension, which connects to Language Server,
@@ -112,6 +120,7 @@ export interface AWSInitializationOptions {
             notifications?: boolean
         }
     }
+    contextConfiguration?: ContextConfiguration
     /**
      * Global region configuration option set by the client application.
      * Server implementations can use this value to preconfigure SDKs, API clients, etc. at server process startup.

--- a/runtimes/protocol/lsp.ts
+++ b/runtimes/protocol/lsp.ts
@@ -47,11 +47,40 @@ export class AutoParameterStructuresProtocolRequestType<P, R, PR, E, RO>
     }
 }
 
+/**
+ * Configuration interface for setting up local context file indexing.
+ * Controls what files are indexed, size limitations, and indexing behavior.
+ */
 export interface ContextConfiguration {
-    gitIgnoreFilePatterns?: string[]
+    /**
+     * Array of file patterns to be be excluded from indexing. Patterns must follow the git ignore convention.
+     */
+    ignoreFilePatterns?: string[]
+
+    /**
+     * Flag to determine whether symbolic links should be included in indexing.
+     * When true, symlinks will be added to the repomap created before indexing.
+     * When false or undefined, symlinks will be ignored.
+     */
     includeSymLinks?: boolean
-    validFileExtensions?: string[]
+
+    /**
+     * List of file extensions that should be included.
+     * Example: ['.ts', '.js', '.json']
+     * Files with extensions not in this list will be ignored.
+     */
+    fileExtensions?: string[]
+
+    /**
+     * Maximum allowed size for individual files in megabytes.
+     * Files larger than this limit will not be included in the index.
+     */
     maxFileSizeMb?: number
+
+    /**
+     * Maximum allowed size for the entire index in megabytes.
+     * Processing will stop when this limit is reached.
+     */
     maxIndexSizeMb?: number
 }
 


### PR DESCRIPTION
## Problem
Support configuration for file indexing.

## Solution
Add a `ContextConfiguration` in the `InitializeParams` object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
